### PR TITLE
use check_type for variable checking

### DIFF
--- a/R/step-ts-acceleration.R
+++ b/R/step-ts-acceleration.R
@@ -121,14 +121,7 @@ prep.step_ts_acceleration <- function(x, training, info = NULL, ...) {
 
     col_names <- recipes::recipes_eval_select(x$terms, training, info)
 
-    value_data <- info[info$variable %in% col_names, ]
-
-    if(any(value_data$type != "numeric")){
-        rlang::abort(
-            paste0("All variables for `step_hai_hyperbolic` must be `numeric`",
-                   "`integer` `double` classes.")
-        )
-    }
+    recipes::check_type(training[, col_names])
 
     step_ts_acceleration_new(
         terms      = x$terms,

--- a/R/step-ts-velocity.R
+++ b/R/step-ts-velocity.R
@@ -121,14 +121,7 @@ prep.step_ts_velocity <- function(x, training, info = NULL, ...) {
 
     col_names <- recipes::recipes_eval_select(x$terms, training, info)
 
-    value_data <- info[info$variable %in% col_names, ]
-
-    if(any(value_data$type != "numeric")){
-        rlang::abort(
-            paste0("All variables for `step_hai_hyperbolic` must be `numeric`",
-                   "`integer` `double` classes.")
-        )
-    }
+    recipes::check_type(training[, col_names])
 
     step_ts_velocity_new(
         terms      = x$terms,


### PR DESCRIPTION
Hello @spsanderson 👋 

When doing revdepchecking for https://github.com/tidymodels/recipes/pull/993, I found a couple of bug that appears in your variable type checking code, that used to work before, but now doesn't.

I updated your type checking to use {recipes}'s built-in function `check_type()`

This PR should fix this! And can be merged now as it isn't dependent on  https://github.com/tidymodels/recipes/pull/993.

This also removes the typo of mentioning `step_hai_hyperbolic()`