### PR TITLE
Update for changes coming to rsample

### DIFF
--- a/R/ts-auto-recipe.R
+++ b/R/ts-auto-recipe.R
@@ -47,7 +47,6 @@
 #' splits <- initial_time_split(
 #'  data_tbl
 #'  , prop = 0.8
-#'  , cumulative = TRUE
 #' )
 #'
 #' ts_auto_recipe(

--- a/man/ts_auto_recipe.Rd
+++ b/man/ts_auto_recipe.Rd
@@ -77,7 +77,6 @@ data_tbl <- ts_to_tbl(AirPassengers) \%>\%
 splits <- initial_time_split(
  data_tbl
  , prop = 0.8
- , cumulative = TRUE
 )
 
 ts_auto_recipe(


### PR DESCRIPTION
Hello!

I maintain the `rsample` package and we are changing `initial_time_split()` to error with arguments passed via `...`. This breaks one of the examples in `healthR.ts` which this PR fixes by removing the (unused) argument `cumulative`. 

The changes in rsample: https://github.com/tidymodels/rsample/pull/429